### PR TITLE
gmKtool: Fix python 3.11 unsupported syntax (error on muOS Banana)

### DIFF
--- a/soniccolorsdemastered/tools/Klib/GMblob.py
+++ b/soniccolorsdemastered/tools/Klib/GMblob.py
@@ -309,14 +309,14 @@ class GMIFFDdata(IFFdata):
         options = []
         if self.audiosettings["bitrate"] != 0:
             options.append("-b")
-            options.append(f"{self.audiosettings["bitrate"]}")
+            options.append(f"{self.audiosettings['bitrate']}")
 
         if self.audiosettings["downmix"]:
             options.append("--downmix")
         
         if self.audiosettings["resample"] != 0:
             options.append("--resample")
-            options.append(f"{self.audiosettings["resample"]}")
+            options.append(f"{self.audiosettings['resample']}")
         
         return options
 


### PR DESCRIPTION
Python 3.12 doesn't complain but Python 3.11 is not happy.